### PR TITLE
Add spa option using connect-history-api-fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ $ elm-server path/to/Main.elm
     -V, --version            output the version number
     -o, --output <path>      Path to elm-make output [index.html].
     -s, --start-path <path>  Initial path when opening browser.
+    -a. --spa                Set to something to enable single page application mode
     -w, --watch <directory>  Path to served directory.  Defaults
                               to directory of output file path.
 ```
@@ -58,6 +59,13 @@ $ elm-server src/elm/Main.elm \
     --watch assets \
     --start-path html/index.html
 ```
+
+###### spa
+When you have a Single Page Application with routing on the client side, this mode is for you. It uses the [connect-history-api-fallback](https://github.com/bripkens/connect-history-api-fallback) library.
+
+It currently assumes that you are using index.html as the entry point for your app.
+
+
 
 #### Programmatic Usage
 

--- a/bin.js
+++ b/bin.js
@@ -9,6 +9,7 @@ commander
   .version(version)
   .option('-o, --output <path>', 'Path to elm-make output [index.html].')
   .option('-s, --start-path <path>', 'Initial path when opening browser.')
+  .option('-a, --spa <true>', 'Set to whatever to enable spa mode.')
   .usage('[options] <inputFile> [inputFiles...]');
 
 var descriptionWidth = 35;
@@ -34,5 +35,6 @@ if (!commander.args.length) {
 elmServer(commander.args, {
   output: commander.output,
   startPath: commander.startPath,
-  watch: commander.watch
+  watch: commander.watch,
+  spa: commander.spa
 });

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var browserSync = require('browser-sync');
 var chokidar = require('chokidar');
+var historyApiFallback = require('connect-history-api-fallback');
 var spawn = require('child_process').spawn;
 var platform = require('elm/platform');
 var path = require('path');
@@ -27,6 +28,8 @@ module.exports = function elmServer(inputFilesArg, optsArg) {
       opts.output;
 
   var watch = opts.watch || path.dirname(outputFile);
+  var isSpa = opts.spa || false;
+
   var startPath =
     opts.startPath ||
     (path.extname(outputFile) === '.html' ?
@@ -47,7 +50,10 @@ module.exports = function elmServer(inputFilesArg, optsArg) {
     .on('change', elmMake);
 
   return browserSync({
-    server: watch,
+    server: {
+      baseDir: watch,
+      middleware: isSpa ? [ historyApiFallback() ] : []
+    },
     watchOptions: {
       ignored: /(elm-stuff|\.elm)/
     },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "browser-sync": "^2.10.1",
     "chokidar": "^1.4.1",
+    "connect-history-api-fallback": "^1.1.0",
     "commander": "2.8.0",
     "elm": "^0.16.0",
     "lodash.chunk": "^3.0.1"


### PR DESCRIPTION
First stab at supporting Elm single page apps which uses client side routing.
